### PR TITLE
fix get_config for wBiFPNAdd layer

### DIFF
--- a/layers.py
+++ b/layers.py
@@ -56,6 +56,7 @@ class wBiFPNAdd(keras.layers.Layer):
         config.update({
             'epsilon': self.epsilon
         })
+        return config
 
 
 def bbox_transform_inv(boxes, deltas, mean=None, std=None):


### PR DESCRIPTION
the `get_config` method for the `wBiFPNAddLayer` never returned config, which makes it impossible to deserialize a saved model that uses this layer. Returning the config will fix this.