### PR TITLE
Improve preprocess_image speed & add GPU version of it using CuPy

### DIFF
--- a/inference_frozen_graph.py
+++ b/inference_frozen_graph.py
@@ -54,7 +54,7 @@ def main():
     image = image[:, :, ::-1]
     h, w = image.shape[:2]
     
-    image, scale, offset_h, offset_w = preprocess_image(image, image_size=image_size)
+    image, scale = preprocess_image(image, image_size=image_size)
     anchors = anchors_for_shape((image_size, image_size))
     
     # run network

--- a/inference_quad.py
+++ b/inference_quad.py
@@ -43,7 +43,7 @@ for image_path in glob.glob('datasets/ic15/test_images/*.jpg'):
     image = image[:, :, ::-1]
     h, w = image.shape[:2]
 
-    image, scale, offset_h, offset_w = preprocess_image(image, image_size=image_size)
+    image, scale = preprocess_image(image, image_size=image_size)
     inputs = np.expand_dims(image, axis=0)
     anchors = anchors_for_shape((image_size, image_size), anchor_params=anchor_parameters)
     # run network


### PR DESCRIPTION
Added a small change to increase the preprocess_image function speed slightly on CPU (1-2%) and added GPU version using CuPy (preprocess_image_gpu) to increase the speed by around 60%.